### PR TITLE
Update LoadCommand.cs

### DIFF
--- a/UncreatedWarfare/Commands/LoadCommand.cs
+++ b/UncreatedWarfare/Commands/LoadCommand.cs
@@ -114,6 +114,10 @@ public class LoadCommand : AsyncCommand
                                     amount /= 2;
                             }
 
+                            if (amount > (vehicle.trunkItems.width * vehicle.trunkItems.height)) {
+                                throw ctx.Reply(T.LoadInvalidAmount, ctx.Get(1)!);
+                            }
+
                             if (amount > 0)
                             {
                                 if (!vehicle.transform.TryGetComponent(out VehicleComponent c))

--- a/UncreatedWarfare/Commands/LoadCommand.cs
+++ b/UncreatedWarfare/Commands/LoadCommand.cs
@@ -114,7 +114,8 @@ public class LoadCommand : AsyncCommand
                                     amount /= 2;
                             }
 
-                            if (amount > (vehicle.trunkItems.width * vehicle.trunkItems.height)) {
+                            if (amount > vehicle.trunkItems != null ? vehicle.trunkItems.width * vehicle.trunkItems.height : 100)
+                            {
                                 throw ctx.Reply(T.LoadInvalidAmount, ctx.Get(1)!);
                             }
 


### PR DESCRIPTION
Caused server crash when loading high amounts of items, add check to ensure that items are never above the size of the trunk.