### PR TITLE
Update ClaimToRearmTweaks.cs

### DIFF
--- a/UncreatedWarfare/FOBs/Deployment/Tweaks/ClaimToRearmTweaks.cs
+++ b/UncreatedWarfare/FOBs/Deployment/Tweaks/ClaimToRearmTweaks.cs
@@ -328,9 +328,9 @@ public class ClaimToRearmTweaks : // todo: move this class out of this namespace
             case FirearmClass.BattleRifle:
                 return 0.25f;
             case FirearmClass.LightMachineGun:
-                return 0.5f;
+                return 0.4f;
             case FirearmClass.GeneralPurposeMachineGun:
-                return 0.6f;
+                return 0.5f;
             case FirearmClass.DMR:
                 return 0.3f;
             case FirearmClass.Sniper:
@@ -338,9 +338,9 @@ public class ClaimToRearmTweaks : // todo: move this class out of this namespace
             case FirearmClass.GrenadeLauncher:
                 return 0.2f;
             case FirearmClass.LightAntiTank:
-                return 1f;
+                return 0.7f;
             case FirearmClass.HeavyAntiTank:
-                return 1f;
+                return 0.7f;
             default:
                 return 0.2f;
         }


### PR DESCRIPTION
lower amount of ammo consumed for anti tank rockets as well as machine gun ammo

say an anti tank used 3 rockets  4 smg maganizes 2 dressings 1 smoke 0.7x3+ 0.2x4 + 0.2x1 + 0.1x1 = 3.2 compared to what would have been 4.1, thats basically half an ammo crate for one guy that could have missed every shot. Also mg ammo hella expensive and not accounting for 45 rounder mags.